### PR TITLE
fix: coerce get_sp500_prices return value to Series for yfinance >= 0.2

### DIFF
--- a/algorithmic_trading_utilities/data/yfinance_ops.py
+++ b/algorithmic_trading_utilities/data/yfinance_ops.py
@@ -19,13 +19,18 @@ def get_sp500_prices(start_date: str, end_date: str = None) -> pd.Series:
     sp500_symbol = "^GSPC"  # S&P 500 index symbol in yfinance
     if end_date is None:
         end_date = date.today().isoformat()
-    sp500_prices_df = yfinance.download(
+    sp500_prices = yfinance.download(
         tickers=[sp500_symbol],
         start=start_date,
         end=end_date,
         interval="1d",
     )["Close"]
-    return sp500_prices_df
+    # yfinance >= 0.2 returns a DataFrame (multi-index columns) for single-ticker
+    # downloads; older versions returned a Series. Coerce to Series so the
+    # documented return type holds across yfinance versions.
+    if isinstance(sp500_prices, pd.DataFrame):
+        sp500_prices = sp500_prices.iloc[:, 0]
+    return sp500_prices
 
 
 screeners = [

--- a/tests/test_yfinance_ops.py
+++ b/tests/test_yfinance_ops.py
@@ -32,3 +32,16 @@ class TestGetSp500Prices:
 
         assert isinstance(result, pd.Series)
         assert len(result) == 0
+
+    # yfinance >= 0.2 returns a DataFrame for single-ticker downloads; ensure
+    # the function still returns a Series in that case.
+    def test_coerces_dataframe_to_series(self, mocker):
+        mock_download = mocker.patch("data.yfinance_ops.yfinance.download")
+        mock_close_df = pd.DataFrame({"^GSPC": [100.0, 101.0, 102.0]})
+        mock_download.return_value = {"Close": mock_close_df}
+
+        result = get_sp500_prices("2023-01-01")
+
+        assert isinstance(result, pd.Series)
+        assert len(result) == 3
+        assert list(result.values) == [100.0, 101.0, 102.0]


### PR DESCRIPTION
yfinance >= 0.2 returns a DataFrame with multi-level columns for single-ticker downloads, so `yfinance.download(...)["Close"]` yielded a single-column DataFrame instead of a Series. Callers (e.g. PerformanceMetrics auto-fetch path) that downstream did pd.Series(...) on the result hit "The truth value of a DataFrame is ambiguous" in plot_returns_distribution. Coerce to Series at the boundary so the documented return type holds across yfinance versions.